### PR TITLE
Fix path for included pnp headers

### DIFF
--- a/libs/vision/CMakeLists.txt
+++ b/libs/vision/CMakeLists.txt
@@ -7,7 +7,7 @@ LIST(APPEND vision_EXTRA_SRCS_NAME 	"maps" "maps" "maps-bcks-compat")
 LIST(APPEND vision_EXTRA_SRCS		"${MRPT_SOURCE_DIR}/libs/vision/src/obs/*.cpp" "${MRPT_SOURCE_DIR}/libs/vision/include/mrpt/slam/CObservation*.h")
 LIST(APPEND vision_EXTRA_SRCS_NAME 	"observations" "observations")
 
-LIST(APPEND vision_EXTRA_SRCS		"${MRPT_SOURCE_DIR}/libs/vision/src/pnp/*.cpp" "${MRPT_SOURCE_DIR}/libs/vision/include/mrpt/pnp/*.h")
+LIST(APPEND vision_EXTRA_SRCS		"${MRPT_SOURCE_DIR}/libs/vision/src/pnp/*.cpp" "${MRPT_SOURCE_DIR}/libs/vision/include/mrpt/vision/pnp/*.h")
 LIST(APPEND vision_EXTRA_SRCS_NAME 	"pnp" "pnp")
 
 IF(CMAKE_MRPT_HAS_SIFT_HESS)


### PR DESCRIPTION
The headers are included as source in order to have them visible in e.g. the file structure tree of an IDE.
There was a mistake in the path for the headers in pnp and these were not appearing in the IDE.