### PR TITLE
Added functionality for 2d/3d points to be input as 3xn or nx3 matrices

### DIFF
--- a/libs/vision/src/pnp/pnp_algos.cpp
+++ b/libs/vision/src/pnp/pnp_algos.cpp
@@ -30,212 +30,500 @@
 
 bool mrpt::vision::pnp::CPnP::dls(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat){
     try{
-    #if MRPT_HAS_OPENCV==1
-    
-    Eigen::MatrixXd cam_in_eig=cam_intrinsic.transpose(), img_pts_eig=img_pts.transpose().block(0,0,n,2), obj_pts_eig=obj_pts.transpose(), t_eig;
-    Eigen::Matrix3d R_eig; 
-    cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv(3,3,CV_32F), t_cv(3,1,CV_32F);
-   
-    cv::eigen2cv(cam_in_eig, cam_in_cv);
-    cv::eigen2cv(img_pts_eig, img_pts_cv);
-    cv::eigen2cv(obj_pts_eig, obj_pts_cv);
-    
-    mrpt::vision::pnp::dls d(obj_pts_cv, img_pts_cv);
-    bool ret = d.compute_pose(R_cv,t_cv);
-    
-    cv::cv2eigen(R_cv, R_eig);
-    cv::cv2eigen(t_cv, t_eig);
-    
-    Eigen::Quaterniond q(R_eig);
-    
-    pose_mat << t_eig,q.vec();
-    
-    return ret;
-    
-    #else
-    throw(-1)
-    #endif
+        #if MRPT_HAS_OPENCV==1
+        
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R_eig; 
+        Eigen::MatrixXd t_eig;
+        
+        // Compute pose
+        cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv(3,3,CV_32F), t_cv(3,1,CV_32F);
+       
+        cv::eigen2cv(cam_in_eig, cam_in_cv);
+        cv::eigen2cv(img_pts_eig, img_pts_cv);
+        cv::eigen2cv(obj_pts_eig, obj_pts_cv);
+        
+        mrpt::vision::pnp::dls d(obj_pts_cv, img_pts_cv);
+        bool ret = d.compute_pose(R_cv,t_cv);
+        
+        cv::cv2eigen(R_cv, R_eig);
+        cv::cv2eigen(t_cv, t_eig);
+        
+        Eigen::Quaterniond q(R_eig);
+        
+        pose_mat << t_eig,q.vec();
+        
+        return ret;
+        
+        #else
+        throw(-1)
+        #endif
     }
     catch(int e)
     {
-        if (e==-1)
-            std::cout<<"Please install OpenCV for DLS-PnP" << std::endl;
+        switch(e)
+        {
+            case -1: std::cout << "Please install OpenCV for DLS-PnP" << std::endl;
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
     }
 }
 
 bool mrpt::vision::pnp::CPnP::epnp(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat){
     try{
-    #if MRPT_HAS_OPENCV==1
-    Eigen::MatrixXd cam_in_eig=cam_intrinsic.transpose(), img_pts_eig=img_pts.transpose().block(0,0,n,2), obj_pts_eig=obj_pts.transpose(), t_eig;
-    Eigen::Matrix3d R_eig; 
-    cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv, t_cv;
-    
-    cv::eigen2cv(cam_in_eig, cam_in_cv);
-    cv::eigen2cv(img_pts_eig, img_pts_cv);
-    cv::eigen2cv(obj_pts_eig, obj_pts_cv);
-    
-    mrpt::vision::pnp::epnp e(cam_in_cv, obj_pts_cv, img_pts_cv);
-    e.compute_pose(R_cv,t_cv);
-    
-    cv::cv2eigen(R_cv, R_eig);
-    cv::cv2eigen(t_cv, t_eig);
-    
-    Eigen::Quaterniond q(R_eig);
-    
-    pose_mat << t_eig,q.vec();
-    
-    return true;
-    
-    #else
-    throw(-1);
-    #endif
+        #if MRPT_HAS_OPENCV==1
+        
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R_eig; 
+        Eigen::MatrixXd t_eig;
+        
+        // Compute pose
+        cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv, t_cv;
+        
+        cv::eigen2cv(cam_in_eig, cam_in_cv);
+        cv::eigen2cv(img_pts_eig, img_pts_cv);
+        cv::eigen2cv(obj_pts_eig, obj_pts_cv);
+        
+        mrpt::vision::pnp::epnp e(cam_in_cv, obj_pts_cv, img_pts_cv);
+        e.compute_pose(R_cv,t_cv);
+        
+        cv::cv2eigen(R_cv, R_eig);
+        cv::cv2eigen(t_cv, t_eig);
+        
+        Eigen::Quaterniond q(R_eig);
+        
+        pose_mat << t_eig,q.vec();
+        
+        return true;
+        
+        #else
+        throw(-1);
+        #endif
     }
-    catch(int e)
-    {
-        if (e==-1)
-            std::cout<<"Please install OpenCV for EPnP" << std::endl;
+    catch(int e){
+        switch(e)
+        {
+            case -1: std::cout << "Please install OpenCV for DLS-PnP" << std::endl;
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
     }
 }
 
 bool mrpt::vision::pnp::CPnP::upnp(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat){
     try{
-    #if MRPT_HAS_OPENCV==1
-    Eigen::MatrixXd cam_in_eig=cam_intrinsic.transpose(), img_pts_eig=img_pts.transpose().block(0,0,n,2), obj_pts_eig=obj_pts.transpose(), t_eig;
-    Eigen::Matrix3d R_eig; 
-    cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv, t_cv;
-    
-    cv::eigen2cv(cam_in_eig, cam_in_cv);
-    cv::eigen2cv(img_pts_eig, img_pts_cv);
-    cv::eigen2cv(obj_pts_eig, obj_pts_cv);
-    
-    mrpt::vision::pnp::upnp u(cam_in_cv, obj_pts_cv, img_pts_cv);
-    u.compute_pose(R_cv,t_cv);
-    
-    cv::cv2eigen(R_cv, R_eig);
-    cv::cv2eigen(t_cv, t_eig);
-    
-    Eigen::Quaterniond q(R_eig);
-    
-    pose_mat << t_eig,q.vec();
-    
-    return true;
-    #else
-    throw(-1);
-    #endif
+        #if MRPT_HAS_OPENCV==1
+        
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R_eig; 
+        Eigen::MatrixXd t_eig;
+        
+        // Compute pose
+        cv::Mat cam_in_cv(3,3,CV_32F), img_pts_cv(2,n,CV_32F), obj_pts_cv(3,n,CV_32F), R_cv, t_cv;
+        
+        cv::eigen2cv(cam_in_eig, cam_in_cv);
+        cv::eigen2cv(img_pts_eig, img_pts_cv);
+        cv::eigen2cv(obj_pts_eig, obj_pts_cv);
+        
+        mrpt::vision::pnp::upnp u(cam_in_cv, obj_pts_cv, img_pts_cv);
+        u.compute_pose(R_cv,t_cv);
+        
+        cv::cv2eigen(R_cv, R_eig);
+        cv::cv2eigen(t_cv, t_eig);
+        
+        Eigen::Quaterniond q(R_eig);
+        
+        pose_mat << t_eig,q.vec();
+        
+        return true;
+        #else
+        throw(-1);
+        #endif
     }
     catch(int e)
     {
-        if (e==-1)
-            std::cout<<"Please install OpenCV for UPnP" << std::endl;
+        switch(e)
+        {
+            case -1: std::cout << "Please install OpenCV for DLS-PnP" << std::endl;
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
     }
 }
 
 
 bool mrpt::vision::pnp::CPnP::p3p(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat){
     
-    Eigen::MatrixXd cam_in_eig=cam_intrinsic.transpose(), img_pts_eig=img_pts.transpose(), obj_pts_eig=obj_pts.transpose();
-    Eigen::Matrix3d R_eig; 
-    Eigen::Vector3d t_eig;
-    
-    mrpt::vision::pnp::p3p p(cam_in_eig);
-    bool ret = p.solve(R_eig,t_eig, obj_pts_eig, img_pts_eig);
-    
-    Eigen::Quaterniond q(R_eig);
-    
-    pose_mat << t_eig,q.vec();
-    
-    return ret;
+    try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R; 
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::p3p p(cam_in_eig);
+        bool ret = p.solve(R,t, obj_pts_eig, img_pts_eig);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat << t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }
 
 
 bool mrpt::vision::pnp::CPnP::rpnp(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat){
-    
-    Eigen::MatrixXd cam_in_eig=cam_intrinsic.transpose(), img_pts_eig=img_pts.transpose(), obj_pts_eig=obj_pts.transpose();
-    Eigen::Matrix3d R_eig; 
-    Eigen::Vector3d t_eig;
-    
-    mrpt::vision::pnp::rpnp r(obj_pts_eig, img_pts_eig, cam_in_eig, n);
-    bool ret = r.compute_pose(R_eig,t_eig);
-    
-    Eigen::Quaterniond q(R_eig);
-    
-    pose_mat << t_eig,q.vec();
-    
-    return ret;
+    try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose();
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts;
+            obj_pts_eig=obj_pts;
+        }
+       
+        // Output pose
+        Eigen::Matrix3d R;
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::rpnp r(obj_pts_eig, img_pts_eig, cam_in_eig, n);
+        bool ret = r.compute_pose(R,t);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat << t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }
 
 bool mrpt::vision::pnp::CPnP::ppnp(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat)
 {	
-	Eigen::Matrix3d R(3,3);
-	Eigen::VectorXd t(3);
-	
-	Eigen::MatrixXd obj_pts_=obj_pts.transpose(), img_pts_=img_pts.transpose();
-
-	mrpt::vision::pnp::ppnp p(obj_pts_,img_pts_, cam_intrinsic);
-	
-	bool ret = p.compute_pose(R,t,n);
-	
-	Eigen::Quaterniond q(R);
-	
-	pose_mat << t,q.vec();
-	
-	return ret;
+	try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose();
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts;
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R;
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::ppnp p(obj_pts_eig,img_pts_eig, cam_in_eig);
+        
+        bool ret = p.compute_pose(R,t,n);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat << t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }
 
 bool mrpt::vision::pnp::CPnP::posit(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat)
 {	
-	Eigen::Matrix3d R;
-	Eigen::Vector3d t;
-	
-	Eigen::MatrixXd obj_pts_=obj_pts.transpose(), img_pts_=img_pts.transpose();
-
-	mrpt::vision::pnp::posit p(obj_pts_,img_pts_, cam_intrinsic, n);
-	
-	bool ret = p.compute_pose(R,t);
-    
-	Eigen::Quaterniond q(R);
-	
-	pose_mat << t,q.vec();
-	
-	return ret;
+	try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R;
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::posit p(obj_pts_eig,img_pts_eig, cam_in_eig, n);
+        
+        bool ret = p.compute_pose(R,t);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat << t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }
 
 bool mrpt::vision::pnp::CPnP::lhm(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat)
 {
-    Eigen::Matrix3d R;
-	Eigen::Vector3d t;
-	
-	Eigen::MatrixXd obj_pts_=obj_pts.transpose(), img_pts_=img_pts.transpose();
-    
-    mrpt::vision::pnp::lhm l(obj_pts_, img_pts_, cam_intrinsic, n);
-    
-    bool ret = l.compute_pose(R,t);
-    
-    Eigen::Quaterniond q(R);
-    
-    pose_mat<<t,q.vec();
-    
-    return ret;
-    
+    try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose();
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts;
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R;
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::lhm l(obj_pts_eig, img_pts_eig, cam_intrinsic, n);
+        
+        bool ret = l.compute_pose(R,t);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat<<t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }
 
 bool mrpt::vision::pnp::CPnP::so3(const Eigen::Ref<Eigen::MatrixXd> obj_pts, const Eigen::Ref<Eigen::MatrixXd> img_pts, int n, const Eigen::Ref<Eigen::MatrixXd> cam_intrinsic, Eigen::Ref<Eigen::MatrixXd> pose_mat)
 {
-    Eigen::Matrix3d R;
-	Eigen::Vector3d t;
-	
-	Eigen::MatrixXd obj_pts_=obj_pts.transpose(), img_pts_=img_pts.transpose(), cam_intrinsic_ = cam_intrinsic.transpose();
-    
-    mrpt::vision::pnp::p3p p(cam_intrinsic_);
-    p.solve(R,t, obj_pts_, img_pts_);
-    
-    mrpt::vision::pnp::so3 s(obj_pts_, img_pts_, cam_intrinsic_, n);
-    bool ret = s.compute_pose(R,t);
-    
-    Eigen::Quaterniond q(R);
-    
-    pose_mat<<t,q.vec();
-    
-    return ret;
-    
+    try{
+        // Input 2d/3d correspondences and camera intrinsic matrix 
+        Eigen::MatrixXd cam_in_eig,img_pts_eig, obj_pts_eig;
+        
+        // Check for consistency of input matrix dimensions
+        if (img_pts.rows() != obj_pts.rows() || img_pts.cols() !=obj_pts.cols())
+            throw(2);
+        else if (cam_intrinsic.rows()!=3 || cam_intrinsic.cols()!=3)
+            throw(3);
+            
+        if(obj_pts.rows() < obj_pts.cols())
+        {
+            cam_in_eig=cam_intrinsic.transpose();
+            img_pts_eig=img_pts.transpose().block(0,0,n,2);
+            obj_pts_eig=obj_pts.transpose();
+        }
+        else
+        {
+            cam_in_eig=cam_intrinsic;
+            img_pts_eig=img_pts.block(0,0,n,2);
+            obj_pts_eig=obj_pts;
+        }
+        
+        // Output pose
+        Eigen::Matrix3d R;
+        Eigen::Vector3d t;
+        
+        // Compute pose
+        mrpt::vision::pnp::p3p p(cam_in_eig);
+        p.solve(R,t, obj_pts_eig, img_pts_eig);
+        
+        mrpt::vision::pnp::so3 s(obj_pts_eig, img_pts_eig, cam_in_eig, n);
+        bool ret = s.compute_pose(R,t);
+        
+        Eigen::Quaterniond q(R);
+        
+        pose_mat<<t,q.vec();
+        
+        return ret;
+    }
+    catch(int e)
+    {
+        switch(e)
+        {
+            case  2: std::cout << "2d/3d correspondences mismatch\n Check dimension of obj_pts and img_pts" << std::endl;
+            case  3: std::cout << "Camera intrinsic matrix does not have 3x3 dimensions " << std::endl;
+        }
+        return false;
+    }
 }

--- a/libs/vision/src/pnp/ppnp.cpp
+++ b/libs/vision/src/pnp/ppnp.cpp
@@ -11,7 +11,7 @@ mrpt::vision::pnp::ppnp::ppnp(const Eigen::MatrixXd& obj_pts, const Eigen::Matri
 	C = cam_intrinsic;
 }
 
-bool mrpt::vision::pnp::ppnp::compute_pose(Eigen::Matrix3d& R, Eigen::VectorXd& t, int n)
+bool mrpt::vision::pnp::ppnp::compute_pose(Eigen::Matrix3d& R, Eigen::Vector3d& t, int n)
 {
 	double tol=0.0001;
 	

--- a/libs/vision/src/pnp/ppnp.h
+++ b/libs/vision/src/pnp/ppnp.h
@@ -33,7 +33,7 @@ namespace mrpt
                  * @param n Number of 2d/3d correspondences
                  * @return 
                  */
-                bool compute_pose(Eigen::Matrix3d& R, Eigen::VectorXd& t, int n);
+                bool compute_pose(Eigen::Matrix3d& R, Eigen::Vector3d& t, int n);
                 
                 private:
                 


### PR DESCRIPTION
**mrpt->vision->pnp_algos.cpp; mrpt->vision->ppnp.h, ppnp.cpp** 
*   *Added functionality for 2d/3d points to be input as 3xn or nx3 matrices* ...
* (*Changed VectorXd&t to Vector3d&t for translation vector in ppnp*) 
* (*Made code format of pnp_algos.cpp to be very consistent*) 

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )