### PR TITLE
Fixed axis for np.mean which corrects plots with mean and median

### DIFF
--- a/libs/vision/src/pnp/ppnp.cpp
+++ b/libs/vision/src/pnp/ppnp.cpp
@@ -13,7 +13,7 @@ mrpt::vision::pnp::ppnp::ppnp(const Eigen::MatrixXd& obj_pts, const Eigen::Matri
 
 bool mrpt::vision::pnp::ppnp::compute_pose(Eigen::Matrix3d& R, Eigen::Vector3d& t, int n)
 {
-	double tol=0.0001;
+	double tol=0.00001;
 	
 	Eigen::MatrixXd I=Eigen::MatrixXd::Identity(n, n), A(n,n), Y(n,3), E(n,3), E_old(n,3), U,V, I3 =Eigen::MatrixXd::Identity(3, 3), PR, Z=Eigen::MatrixXd::Zero(n, n);
 	Eigen::VectorXd e(n), II(n), c(3), Zmindiag(n);

--- a/python/samples/pnp_perf_comp.py
+++ b/python/samples/pnp_perf_comp.py
@@ -37,9 +37,7 @@ n_iter = 100
 
 class HighlightLines(plugins.PluginBase):
     """A plugin for an interactive legend.
-
     Inspired by http://bl.ocks.org/simzou/6439398
-
     """
 
     JAVASCRIPT = """
@@ -51,7 +49,6 @@ class HighlightLines(plugins.PluginBase):
     function InteractiveLegend(fig, props){
         mpld3.Plugin.call(this, fig, props);
     };
-
     InteractiveLegend.prototype.draw = function(){
         var labels = new Array();
         for(var i=0; i<this.props.labels.length; i++){
@@ -61,11 +58,9 @@ class HighlightLines(plugins.PluginBase):
             obj.visible = false;
             labels.push(obj);
         }
-
         var ax = this.fig.axes[0]
         var legend = this.fig.canvas.append("svg:g")
                                .attr("class", "legend");
-
         // add the rectangles
         legend.selectAll("rect")
                 .data(labels)
@@ -80,7 +75,6 @@ class HighlightLines(plugins.PluginBase):
                 .attr("class", "legend-box")
                 .style("fill", "white")
                 .on("click", click)
-
         // add the text
         legend.selectAll("text")
                 .data(labels)
@@ -92,7 +86,6 @@ class HighlightLines(plugins.PluginBase):
                 return ax.position[1]+ i * 25
               })
               .text(function(d) { return d.label })
-
         // specify the action on click
         function click(d,i){
             d.visible = !d.visible;
@@ -104,7 +97,6 @@ class HighlightLines(plugins.PluginBase):
               })
             d3.select(d.line.path[0][0])
                 .style("stroke-opacity", d.visible ? 1 : d.line.props.alpha);
-
         }
     };
     """
@@ -255,6 +247,11 @@ def display_comparison_plot_mpld3(t, arr, names, line_styles, title, xtitle, yti
 
 
 def calc_err(pose1, pose2):
+
+    if np.any(np.isnan(pose1)) or np.log10(np.linalg.norm(pose1)) > 5:
+        err = [0, 0]
+        return err
+
     # Percent error in translation
     t_est = np.array(pose1[0:3])
     t = np.array(pose2[0:3])
@@ -336,10 +333,10 @@ def err_plot():
         err_net_t.append(err_t)
         err_net_q.append(err_q)
 
-    mean_err_t = np.mean(err_net_t, axis=1)
-    mean_err_q = np.mean(err_net_q, axis=1)
-    median_err_t = np.median(err_net_t, axis=1)
-    median_err_q = np.median(err_net_q, axis=1)
+    mean_err_t = np.mean(err_net_t, axis=0)
+    mean_err_q = np.mean(err_net_q, axis=0)
+    median_err_t = np.median(err_net_t, axis=0)
+    median_err_q = np.median(err_net_q, axis=0)
 
     for i in np.arange(0, n_algos):
         print 'mean_err_t_' + algo_names[i] + '=', mean_err_t[i], 'median_err_t_' + algo_names[i] + '=', median_err_t[i]
@@ -353,9 +350,9 @@ def err_plot():
     s = '<h2> Translation error and Rotation error for 100 iterations (R - Randomly varying, t - fixed) </h2>'
 
     s1 = display_comparison_plot_mpld3(it, err_net_t, names=algo_names, line_styles=algo_ls,
-                                       title='Translation %Error Plot', xtitle='Iteration', ytitle='%$e_t$', ylim=[0, 2], figname='err_t')
+                                       title='% Translation Error Plot', xtitle='Iteration', ytitle='e_t', ylim=[0, 2], figname='err_t')
     s2 = display_comparison_plot_mpld3(it, err_net_q, names=algo_names, line_styles=algo_ls,
-                                       title='Rotation Error Plot (deg)', xtitle='Iteration', ytitle='$e_q$', ylim=[0, 1], figname='err_q')
+                                       title='Rotation Error Plot (deg)', xtitle='Iteration', ytitle='e_q', ylim=[0, 1], figname='err_q')
 
     s = s + '\n <table > \n <tr > \n <td > \n' + s1 + \
         '</td > \n <td> \n' + s2 + '</td> \n </tr> \n </table> \n'
@@ -366,16 +363,12 @@ def err_plot():
     comp_arr = np.zeros([n_iter,2])
     for i in np.arange(0,n_iter):
         comp_arr[i,:] = 2*mean_err_p3p
-
-
     nconv_epnp = float(np.sum(err_epnp>comp_arr))/n_iter*100
     nconv_dls  = float(np.sum(err_dls>comp_arr))/n_iter*100
     nconv_ppnp  = float(np.sum(err_ppnp>comp_arr))/n_iter*100
     nconv_posit  = float(np.sum(err_posit>comp_arr))/n_iter*100
     nconv_lhm  = float(np.sum(err_lhm>comp_arr))/n_iter*100
     nconv_p3p  = float(np.sum(err_p3p>comp_arr))/n_iter*100
-
-
     plt.figure()
     xvals = ['epnp', 'dls', 'ppnp', 'posit','lhm', 'p3p']
     xvals_int = np.arange(0,n_algos)
@@ -443,11 +436,11 @@ def err_statistics_fcn_n():
             err_net_t.append(err_t)
             err_net_q.append(err_q)
 
-        mean_err_t_net.append(np.mean(err_net_t, axis=1))
-        mean_err_q_net.append(np.mean(err_net_q, axis=1))
+        mean_err_t_net.append(np.mean(err_net_t, axis=0))
+        mean_err_q_net.append(np.mean(err_net_q, axis=0))
 
-        median_err_t_net.append(np.median(err_net_t, axis=1))
-        median_err_q_net.append(np.median(err_net_q, axis=1))
+        median_err_t_net.append(np.median(err_net_t, axis=0))
+        median_err_q_net.append(np.median(err_net_q, axis=0))
 
     it = np.arange(5, 25)
 
@@ -459,14 +452,14 @@ def err_statistics_fcn_n():
     s = '<h2> Mean and Median error in Translation and Rotation with varying 2d/3d correspondences (n) </h2>'
 
     s1 = display_comparison_plot_mpld3(it, mean_err_t_net, names=algo_names, line_styles=algo_ls,
-                                       title='Mean Translation %Error Plot', xtitle='n', ytitle=r'% $\bar{e}_t$', ylim=[0, 10], figname='mean_err_t')
+                                       title='Mean Translation %Error Plot', xtitle='n', ytitle=r'% Translation error e_t', ylim=[0, 10], figname='mean_err_t')
     s2 = display_comparison_plot_mpld3(it, mean_err_q_net, names=algo_names, line_styles=algo_ls,
-                                       title='Mean Rotation Error Plot (deg)', xtitle='n', ytitle=r'$\bar{e}_q$', ylim=[0, 0.5], figname='mean_err_q')
+                                       title='Mean Rotation Error Plot (deg)', xtitle='n', ytitle=r'Rotation error e_q (deg)', ylim=[0, 0.5], figname='mean_err_q')
 
     s3 = display_comparison_plot_mpld3(it, median_err_t_net, names=algo_names, line_styles=algo_ls,
-                                       title='Median Translation %Error Plot', xtitle='n', ytitle=r'% $\tilde{e}_t$', ylim=[0, 1], figname='median_err_t')
+                                       title='Median Translation %Error Plot', xtitle='n', ytitle=r'% Translation error e_t', ylim=[0, 1], figname='median_err_t')
     s4 = display_comparison_plot_mpld3(it, median_err_q_net, names=algo_names, line_styles=algo_ls,
-                                       title='Median Rotation Error Plot (deg)', xtitle='n', ytitle=r'$\tilde{e}_q$', ylim=[0, 0.5], figname='median_err_q')
+                                       title='Median Rotation Error Plot (deg)', xtitle='n', ytitle=r'Rotation error e_q(deg)', ylim=[0, 0.5], figname='median_err_q')
 
     s = s + '\n<table>\n <tr>\n <td>\n' + s1 + '</td>\n <td>\n' + s2 + '</td>\n </tr>\n' + \
         '\n<tr>\n <td>\n' + s3 + '\n</td>\n <td>\n' + s4 + '\n</td>\n </tr>\n </table>\n'
@@ -529,11 +522,11 @@ def err_statistics_fcn_sigma():
             err_net_t.append(err_t)
             err_net_q.append(err_q)
 
-        mean_err_t_net.append(np.mean(err_net_t, axis=1))
-        mean_err_q_net.append(np.mean(err_net_q, axis=1))
+        mean_err_t_net.append(np.mean(err_net_t, axis=0))
+        mean_err_q_net.append(np.mean(err_net_q, axis=0))
 
-        median_err_t_net.append(np.median(err_net_t, axis=1))
-        median_err_q_net.append(np.median(err_net_q, axis=1))
+        median_err_t_net.append(np.median(err_net_t, axis=0))
+        median_err_q_net.append(np.median(err_net_q, axis=0))
 
     it = np.arange(0.001, 0.010, 0.001)
 
@@ -546,14 +539,14 @@ def err_statistics_fcn_sigma():
     s = '\n<h2>\n Mean and Median error in Translation and Rotation with varying noise variance (sigma)\n </h2>\n'
 
     s1 = display_comparison_plot_mpld3(it, mean_err_t_net, names=algo_names, line_styles=algo_ls, title='Mean Translation %Error Plot',
-                                       xtitle=r'\sigma', ytitle=r'% $\bar{e}_t$', ylim=[0, 10], figname='mean_sigma_err_t')
+                                       xtitle=r'\sigma', ytitle=r'% Translation error e_t', ylim=[0, 10], figname='mean_sigma_err_t')
     s2 = display_comparison_plot_mpld3(it, mean_err_q_net, names=algo_names, line_styles=algo_ls, title='Mean Rotation Error Plot (deg)',
-                                       xtitle=r'\sigma', ytitle=r'$\bar{e}_q$', ylim=[0, 0.5], figname='mean_sigma_err_q')
+                                       xtitle=r'\sigma', ytitle=r'Rotation error e_q (deg)', ylim=[0, 0.5], figname='mean_sigma_err_q')
 
     s3 = display_comparison_plot_mpld3(it, median_err_t_net, names=algo_names, line_styles=algo_ls, title='Median Translation %Error Plot',
-                                       xtitle=r'\sigma', ytitle=r'% $\tilde{e}_t$', ylim=[0, 1], figname='median_sigma_err_t')
+                                       xtitle=r'\sigma', ytitle=r'% Translation error e_t', ylim=[0, 1], figname='median_sigma_err_t')
     s4 = display_comparison_plot_mpld3(it, median_err_q_net, names=algo_names, line_styles=algo_ls, title='Median Rotation Error Plot (deg)',
-                                       xtitle=r'\sigma', ytitle=r'$\tilde{e}_q$', ylim=[0, 0.5], figname='median_sigma_err_q')
+                                       xtitle=r'\sigma', ytitle=r'Rotation error e_q (deg)', ylim=[0, 0.5], figname='median_sigma_err_q')
 
     s = s + '\n<table>\n <tr>\n <td>\n' + s1 + '\n</td>\n <td>\n' + s2 + '\n</td>\n </tr>\n' + \
         '\n<tr>\n <td>\n' + s3 + '\n</td> \n<td>\n' + s4 + '\n</td>\n </tr>\n </table>\n'
@@ -626,26 +619,56 @@ def time_comp():
     return s
 
 # Introduction and links to various files
-ss = """<h1> Introduction </h1>
+ss = """<!DOCTYPE html>
+<html>
+<body bgcolor="#E6E6FA">
 <br>
-<embed src = "https://www.dropbox.com/s/9m4rw8sl868xrob/pnp_intro-1.png?raw=1 #toolbar=0&navpanes=0&scrollbar=0" width = "1000" height = "1500" >
+<CENTER>
+<embed src = "https://www.dropbox.com/s/a266gqe3o0typpg/pnp_intro1.png?raw=1 #toolbar=0&navpanes=0&scrollbar=0" width = "1000" height = "1250" ALIGN=CENTER>
 <br>
-<embed src = "https://www.dropbox.com/s/e3ll5ptjm9dnoev/pnp_intro-2.png?raw=1 #toolbar=0&navpanes=0&scrollbar=0" width = "1000" height = "600" >
+<embed src = "https://www.dropbox.com/s/5v8n4edc7g8q8tu/pnp_intro2.png?raw=1 #toolbar=0&navpanes=0&scrollbar=0" width = "1000" height = "1250" ALIGN=CENTER>
+<br>
+<embed src = "https://www.dropbox.com/s/6bdadtn99tthth0/pnp_intro3.png?raw=1 #toolbar=0&navpanes=0&scrollbar=0" width = "1000" height = "650" ALIGN=CENTER>
 <br>
 <h1> Sample Pose Estimation using Camera Calib application of MRPT </h1>
 <br>
-<iframe src = "https://www.youtube.com/embed/aGd7ZyrcwaE" width = "960" height = "540" frameborder = "0" allowfullscreen > </iframe >
-<br>
-<br>
-<h1> Performance Comparison using python interface in MRPT(pnp_perf_comp.py) </h1>"""
+<iframe src = "https://www.youtube.com/embed/aGd7ZyrcwaE" width = "960" height = "540" frameborder = "0" allowfullscreen ALIGN=CENTER> </iframe >
 
+<br>
+<br>
+<h1> Performance Comparison using python interface in MRPT(pnp_perf_comp.py) </h1>
+<div>
+<h3> Plots are interactive <br>
+    * Click on legend box to solidy the particular algorithm <br>
+    * Pan and Zoom at lower left corner  </h3>
+</div>"""
+
+print 'Test1 - Variation in error for 100 iterations \n'
 s1 = err_plot()
-s2 = err_statistics_fcn_sigma()
-s3 = err_statistics_fcn_n()
-s4 = time_comp()
+print 'Test1 Complete \n\n'
+sys.stdout.flush()
 
-s5 = """ <h1> MRPT Merge Pull Request </h1>
- <a href="https://github.com/MRPT/mrpt/pull/310">Link to PnP Algorithm Pull Request </a>
+print 'Test2 - Variation in error with image pixel noise standard deviation\n'
+s2 = err_statistics_fcn_sigma()
+print 'Test2 Complete\n\n'
+sys.stdout.flush()
+
+print 'Test3 - Variation in error with number of 2d/3d correspondences\n'
+s3 = err_statistics_fcn_n()
+print 'Test3 Complete\n\n'
+sys.stdout.flush()
+
+print 'Test4 - Average computation time per algorithm\n'
+s4 = time_comp()
+print 'Test 4 Complete \n\n'
+
+s5 = """<h1> MRPT Merge Pull Request </h1>
+  <h3>
+  <a href="https://github.com/MRPT/mrpt/pull/310">Link to PnP Algorithm Pull Request </a>
+  </h3>
+</CENTER>
+</body>
+</html>
 """
 
 ss = ss + s1 + s2 + s3 + s4 + s5

--- a/python/samples/pnp_perf_comp.py
+++ b/python/samples/pnp_perf_comp.py
@@ -9,8 +9,18 @@ import timeit
 import mpld3
 from mpld3 import plugins, utils
 
+# Install tabulate using "pip-install tabulate"
+from tabulate import tabulate
+
+import os
+
+
+def clear(): os.system('clear')
+# Function to clear screen
 import pymrpt
 
+
+# Matplotlib figure parameters
 mpl.rcParams['figure.figsize'] = (12.0, 8.0)
 plt.rcParams.update({'axes.titlesize': 30, 'axes.labelsize': 20, 'xtick.labelsize': 15, 'ytick.labelsize': 15,
                      'figure.titlesize': 40})
@@ -18,10 +28,16 @@ plt.rcParams.update({'axes.titlesize': 30, 'axes.labelsize': 20, 'xtick.labelsiz
 # Define number of points and camera parameters
 n = 10
 sigma = 0.0005
+n_range = range(5, 25)
+sigma_range = np.arange(0.0001, 0.001, 0.0001)
 f = 1.0
 cx = 0.0
 cy = 0.0
 cam_intrinsic = np.array([[f, 0.0, cx], [0.0, f, cy], [0.0, 0.0, 1.0]])
+
+# Define constants for serial outputting results
+checkmark = u'\u2713'
+l_progress_bar = 50
 
 # Instantiate pnp module
 pnp = pymrpt.pnp(n)
@@ -36,6 +52,7 @@ n_iter = 100
 
 
 class HighlightLines(plugins.PluginBase):
+    # css format for interactive d3 plots
     """A plugin for an interactive legend.
     Inspired by http://bl.ocks.org/simzou/6439398
     """
@@ -119,6 +136,7 @@ css = """
 
 
 def vector2RotMat(vec, theta=0):
+    # Function to convert from axis, angle to rotation matrix
     # Rodrigues rotation formula
     n_check = np.linalg.norm(vec)
 
@@ -136,6 +154,7 @@ def vector2RotMat(vec, theta=0):
 
 
 def quatvec2RotMat(q):
+    # Function to convert from quaternion to Rotaiton matrix
     qw = np.sqrt(1 - np.linalg.norm(q) * np.linalg.norm(q))
     qx = q[0]
     qy = q[1]
@@ -151,6 +170,7 @@ def quatvec2RotMat(q):
 
 
 def RotMat2quat(R):
+    # Function to convert from rotation matrix to Quaternion
     qw = np.sqrt(1 + R[0, 0] + R[1, 1] + R[2, 2]) / 2
 
     if qw > 0.01:
@@ -224,6 +244,7 @@ def display_comparison_plot(t, arr, names, line_styles, title, xtitle, ytitle, y
 
 
 def display_comparison_plot_mpld3(t, arr, names, line_styles, title, xtitle, ytitle, ylim, figname):
+    # Function used to generate interactive d3 plots in html
     f, ax = plt.subplots()
     lines = []
     for i in np.arange(0, len(names)):
@@ -246,9 +267,74 @@ def display_comparison_plot_mpld3(t, arr, names, line_styles, title, xtitle, yti
     return mpld3.fig_to_html(f)
 
 
-def calc_err(pose1, pose2):
+def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=100):
+    """
+    # Print iterations progress
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        barLength   - Optional  : character length of bar (Int)
+    """
+    formatStr = "{0:." + str(decimals) + "f}"
+    percents = formatStr.format(100 * (iteration / float(total)))
+    filledLength = int(round(barLength * iteration / float(total)))
+    bar = u"\u2588" * filledLength + '-' * (barLength - filledLength)
+    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percents, '%', suffix)),
+    sys.stdout.flush()
+    if iteration == total:
+        sys.stdout.write('\n')
+        sys.stdout.flush()
 
-    if np.any(np.isnan(pose1)) or np.log10(np.linalg.norm(pose1)) > 5:
+
+def printTestStatus(test_index):
+    # Print overall progress of all the tests
+    head_tests = ['#No.', 'Status', 'Description']
+
+    table_tests = [[str(1), '', 'Test for 100 iterations with each algorithm'], [str(2), '',  'Varitaion of error with image pixel noise standard deviation (' +
+                                                                                 u'\u03C3' + ')'], [str(3), '', ' Variation in error with number of 2d/3d correspondences (n)'], [str(4), '', 'Average computation time of each algorithm']]
+
+    for i in range(0, test_index):
+        table_tests[i][1] = checkmark
+
+    print tabulate(table_tests, head_tests, tablefmt='fancy_grid')
+
+    for i in range(0, test_index):
+        printProgress(l_progress_bar, l_progress_bar, prefix='Test' + str(i + 1) +
+                      ' Progress:', suffix='Complete', barLength=50)
+
+
+def printTest1Results(vals):
+    # Function to print results of test 1
+    test1_headers = ['Algo', 'Translation Mean Error', 'Translation Median Error',
+                     'Rotation Mean Error', 'Rotation Median Error']
+
+    test1_table = np.empty([7, 5], dtype=object)
+    test1_table[:, 1:] = vals
+    test1_table[:, 0] = algo_names
+
+    print tabulate(test1_table, test1_headers, tablefmt='fancy_grid')
+
+
+def printTest4Results(vals):
+    # Function to print results of test 4
+    test4_headers = ['Algo', 'Translation Mean Error', 'Translation Median Error',
+                     'Rotation Mean Error', 'Rotation Median Error']
+
+    vals = np.random.rand(7, 1)
+    test4_table = np.empty([7, 2], dtype=object)
+    test4_table[:, 1:] = vals
+    test4_table[:, 0] = algo_names
+
+    print tabulate(test4_table, test4_headers, tablefmt='fancy_grid')
+
+
+def calc_err(pose1, pose2):
+    # FUnction to compute reprojection errors
+    if np.any(np.isnan(pose1)) or np.linalg.norm(pose1) > 1000000:
         err = [0, 0]
         return err
 
@@ -260,7 +346,10 @@ def calc_err(pose1, pose2):
     q_est = pose1[3:6, 0]
     q = pose2[3:6, 0]
 
-    val = np.dot(q_est, q) / np.linalg.norm(q_est) / np.linalg.norm(q)
+    if np.linalg.norm(q) != 0 and np.linalg.norm(q_est):
+        val = np.dot(q_est, q) / np.linalg.norm(q_est) / np.linalg.norm(q)
+    else:
+        val = 1
 
     if val > 1:
         val = 1
@@ -282,6 +371,7 @@ def calc_err(pose1, pose2):
 
 
 def err_plot():
+    # Test 1
     # Define object points and image points
 
     obj_pts = np.random.randint(-40, 40, [n, 3])
@@ -332,16 +422,23 @@ def err_plot():
 
         err_net_t.append(err_t)
         err_net_q.append(err_q)
-
+        printProgress(it, n_iter, prefix='Test' + str(1) +
+                      ' Progress:', suffix='Complete', barLength=50)
     mean_err_t = np.mean(err_net_t, axis=0)
     mean_err_q = np.mean(err_net_q, axis=0)
     median_err_t = np.median(err_net_t, axis=0)
     median_err_q = np.median(err_net_q, axis=0)
 
+    vals = np.empty([7, 4])
+    vals[:, 0] = mean_err_t
+    vals[:, 1] = median_err_t
+    vals[:, 2] = mean_err_q
+    vals[:, 3] = median_err_q
+    """
     for i in np.arange(0, n_algos):
         print 'mean_err_t_' + algo_names[i] + '=', mean_err_t[i], 'median_err_t_' + algo_names[i] + '=', median_err_t[i]
         print 'mean_err_q_' + algo_names[i] + '=', mean_err_q[i], 'median_err_q_' + algo_names[i] + '=', median_err_q[i]
-
+    """
     it = np.arange(0, n_iter)
 
     err_net_t = np.array(err_net_t)
@@ -357,7 +454,7 @@ def err_plot():
     s = s + '\n <table > \n <tr > \n <td > \n' + s1 + \
         '</td > \n <td> \n' + s2 + '</td> \n </tr> \n </table> \n'
 
-    return s
+    return s, vals
 
     """
     comp_arr = np.zeros([n_iter,2])
@@ -382,13 +479,13 @@ def err_plot():
 
 
 def err_statistics_fcn_n():
-
+    # Test 2
     mean_err_t_net = []
     mean_err_q_net = []
     median_err_t_net = []
     median_err_q_net = []
 
-    for n in np.arange(5, 25):
+    for n in n_range:
         # Define object points and image points
         obj_pts = np.random.randint(-40, 40, [n, 3])
         obj_pts = obj_pts.astype(float)
@@ -441,6 +538,9 @@ def err_statistics_fcn_n():
 
         median_err_t_net.append(np.median(err_net_t, axis=0))
         median_err_q_net.append(np.median(err_net_q, axis=0))
+
+        printProgress(n - 5, len(n_range), prefix='Test' + str(3) +
+                      ' Progress:', suffix='Complete', barLength=50)
 
     it = np.arange(5, 25)
 
@@ -467,7 +567,7 @@ def err_statistics_fcn_n():
 
 
 def err_statistics_fcn_sigma():
-
+    # Test 3
     mean_err_t_net = []
     mean_err_q_net = []
     median_err_t_net = []
@@ -475,7 +575,7 @@ def err_statistics_fcn_sigma():
 
     n = 10
 
-    for sigma in np.arange(0.0001, 0.0010, 0.0001):
+    for sigma in sigma_range:
         # Define object points and image points
         obj_pts = np.random.randint(-40, 40, [n, 3])
         obj_pts = obj_pts.astype(float)
@@ -527,6 +627,9 @@ def err_statistics_fcn_sigma():
 
         median_err_t_net.append(np.median(err_net_t, axis=0))
         median_err_q_net.append(np.median(err_net_q, axis=0))
+
+        printProgress(sigma * 1000, len(sigma_range), prefix='Test' + str(2) +
+                      ' Progress:', suffix='Complete', barLength=50)
 
     it = np.arange(0.001, 0.010, 0.001)
 
@@ -555,7 +658,7 @@ def err_statistics_fcn_sigma():
 
 
 def time_comp():
-
+    # Test 4
     obj_pts_store = []
     img_pts_store = []
     n_max = 50
@@ -609,6 +712,8 @@ def time_comp():
 
         tcomp_storage.append(tcomp)
 
+        printProgress(n - n_start, len(range(n_start, n_max, n_step)), prefix='Test' + str(4) +
+                      ' Progress:', suffix='Complete', barLength=50)
     it = np.arange(n_start, n_max, n_step)
     tcomp_storage = np.array(tcomp_storage)
 
@@ -643,24 +748,39 @@ ss = """<!DOCTYPE html>
     * Pan and Zoom at lower left corner  </h3>
 </div>"""
 
-print 'Test1 - Variation in error for 100 iterations \n'
-s1 = err_plot()
-print 'Test1 Complete \n\n'
-sys.stdout.flush()
+# sys.stderr.write('\x1b[2J\x1b[H')
+clear()
+printTestStatus(0)
+printProgress(0, len(range(5, 25)), prefix='Test' + str(1) +
+              ' Progress:', suffix='Complete', barLength=50)
+s1, vals = err_plot()
 
-print 'Test2 - Variation in error with image pixel noise standard deviation\n'
+# sys.stderr.write('\x1b[2J\x1b[H')
+clear()
+printTestStatus(1)
+printProgress(0, len(range(5, 25)), prefix='Test' + str(2) +
+              ' Progress:', suffix='Complete', barLength=50)
 s2 = err_statistics_fcn_sigma()
-print 'Test2 Complete\n\n'
-sys.stdout.flush()
 
-print 'Test3 - Variation in error with number of 2d/3d correspondences\n'
+# sys.stderr.write('\x1b[2J\x1b[H')
+clear()
+printTestStatus(2)
+printProgress(0, len(range(5, 25)), prefix='Test' + str(3) +
+              ' Progress:', suffix='Complete', barLength=50)
 s3 = err_statistics_fcn_n()
-print 'Test3 Complete\n\n'
-sys.stdout.flush()
 
-print 'Test4 - Average computation time per algorithm\n'
+# sys.stderr.write('\x1b[2J\x1b[H')
+clear()
+printTestStatus(3)
+printProgress(0, len(range(5, 25)), prefix='Test' + str(4) +
+              ' Progress:', suffix='Complete', barLength=50)
 s4 = time_comp()
-print 'Test 4 Complete \n\n'
+
+# sys.stderr.write('\x1b[2J\x1b[H')
+clear()
+printTestStatus(4)
+print '\n\nResults of Test 1 \n\n'
+printTest1Results(vals)
 
 s5 = """<h1> MRPT Merge Pull Request </h1>
   <h3>


### PR DESCRIPTION
**mrpt->python->samples->pnp_perf_comp.py** 
*   *Changed axis=1 to axis=0 for mean and median* ...
* (*This fixes mean and median overshooting in d3 plots*) 
* (*Also, did a minor change in tolerance for algorithm ppnp*) 
* (*Added formatted output for viewing status in terminal as tests are running*) 
* (*[Link to video](https://www.youtube.com/watch?v=RBwVlwWKB1I)*) 

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

